### PR TITLE
Flip sign fix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip

--- a/cartesia-metal/cartesia_metal/interface.py
+++ b/cartesia-metal/cartesia_metal/interface.py
@@ -79,6 +79,7 @@ def ssd_update(
     dt_max: float,
     state: mx.array,
     softplus: bool = True,
+    flip_A_sign: bool = False,
     z: Optional[mx.array] = None,
 ) -> Tuple[mx.array, mx.array]:
     """Updates the state space model with the given inputs and parameters.
@@ -109,10 +110,14 @@ def ssd_update(
 
     dt = mx.clip(dt, a_min=dt_min, a_max=dt_max).astype(dt.dtype)
 
+    log_decay = dt
     if A is not None:
-        decay = mx.exp(dt * A.reshape(1, -1))  # (b, h)
-    else:
-        decay = mx.exp(dt)
+        log_decay = log_decay * A.reshape(1, -1)
+
+    if flip_A_sign is True:
+        log_decay = -log_decay
+
+    decay = mx.exp(log_decay)
 
     if z is not None:
         x, state = ssd_update_(x, dt, decay, B, C, D, z, state)

--- a/cartesia-mlx/README.md
+++ b/cartesia-mlx/README.md
@@ -16,6 +16,7 @@ Note: This package has been tested on macOS Sonoma 14.1 with the M3 chip.
 ### Language Models
 - `cartesia-ai/Llamba-1B-4bit-mlx` 
 - `cartesia-ai/Llamba-3B-4bit-mlx`
+- `cartesia-ai/Llamba-8B-4bit-mlx`
 - `cartesia-ai/Llamba-8B-8bit-mlx`
 - `cartesia-ai/Mohawk-v0.1-1.3B-4bit-mlx` 
 - `cartesia-ai/Rene-v0.1-1.3b-4bit-mlx` 


### PR DESCRIPTION
Adds the metal interface option to flip the sign of the state transition. Also contains minor readme update for supported Llamba-8B-4bit-mlx. 